### PR TITLE
[codex] Remove unused setting content style

### DIFF
--- a/src/ui/styles/styles.scss
+++ b/src/ui/styles/styles.scss
@@ -92,14 +92,6 @@
     }
 }
 
-.cmdr-setting-content {
-    height: calc(100% - 10rem);
-
-    .setting-item:first {
-        border-top: none;
-    }
-}
-
 .cmdr-commands-empty {
     display: flex;
     place-items: center;


### PR DESCRIPTION
## Summary

Removes the unused `.cmdr-setting-content` style block that contained the invalid `.setting-item:first` selector.

## Context

The `cmdr-setting-content` class is not applied anywhere in the current source. The invalid selector therefore had no runtime effect, but Lightning CSS warned about it during production builds.

## Validation

- `pnpm build` (the Lightning CSS `:first` warning is gone; the existing Vite root `outDir` warning remains)
- `pnpm lint:check`
- `pnpm test:coverage`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed obsolete styling rules to streamline the codebase.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alephpiece/obsidian-slash-commander/pull/106)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->